### PR TITLE
dist_sensor blocking and negative distance fix.

### DIFF
--- a/car/dist_sensor.py
+++ b/car/dist_sensor.py
@@ -2,13 +2,14 @@ import RPi.GPIO as GPIO
 import time
 
 class DistSensor:
+    max_scan_time = 0.1
+
     def __init__(self, trig_pin, echo_pin):
         self.trig_pin = trig_pin
         self.echo_pin = echo_pin
 
         GPIO.setup(trig_pin, GPIO.OUT)
         GPIO.setup(echo_pin, GPIO.IN)
-
 
     def read_distance(self):
         """Read the distance sensor"""
@@ -21,12 +22,13 @@ class DistSensor:
         GPIO.output(self.trig_pin, GPIO.LOW)
 
         time_start = time.time()
-        time_end = time.time()
-
-        while GPIO.input(self.echo_pin) == 0:
+        loop_start = time.time()
+        while GPIO.input(self.echo_pin) == 0 and time.time() - loop_start < DistSensor.max_scan_time:
             time_start = time.time()
 
-        while GPIO.input(self.echo_pin) == 1:
+        time_end = time.time()
+        loop_start = time.time()
+        while GPIO.input(self.echo_pin) == 1 and time.time() - loop_start < DistSensor.max_scan_time:
             time_end = time.time()
 
         duration = time_end - time_start


### PR DESCRIPTION
dist_sensor blocking solved with time limit.

dist_sensor negative distance error solved, by measuring time_end after the second while. This way it is guaranteed that time_end - time_start is positive, even if the second while loop does not run.